### PR TITLE
Rebuild task manager prototype in Next.js

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,69 @@
+# Beekeeper Task Manager — JavaScript Reimplementation Plan
+
+## 1. Guiding Principles
+- Deliver a cohesive **TypeScript-first** mono-repo using a Next.js 14 App Router frontend with shadcn/ui components and tRPC-backed API routes.
+- Favor server actions and server components for data mutation/fetching while keeping business logic inside shared domain modules.
+- Maintain a clean separation between **domain models**, **data adapters** (initially in-memory), and **presentation** so we can later swap persistence without rewriting UI flows.
+- Ensure accessibility and responsive design from the start (keyboard support, ARIA labels, high-contrast theme toggle).
+
+## 2. High-Level Architecture
+- `/apps/web`: Next.js (App Router) project configured with Tailwind + shadcn/ui, Radix UI primitives, and TanStack Query for client caching.
+- `/packages/domain`: Shared TypeScript models, validators (zod), state machines for task/sub-task lifecycle, and calendar aggregation utilities.
+- `/packages/storage`: Abstract repository interfaces with an initial in-memory adapter; future adapters (PostgreSQL/Prisma) can be added here.
+- `/packages/config`: Shared ESLint, prettier, tsconfig bases.
+- Authentication stubbed with static users/teams during MVP; hook-compatible interface for future providers.
+
+## 3. Milestones & Deliverables
+
+### Milestone A — Project Scaffolding (Day 1)
+1. Initialize pnpm workspace with `apps/web` Next.js project (TypeScript, Tailwind, shadcn).
+2. Configure linting/formatting (ESLint with Next core rules, prettier) and basic CI npm scripts.
+3. Set up shadcn UI registry and import base components (Button, Card, Dialog, Sheet, Table, Calendar, Tabs, Badge, Form).
+4. Establish shared configs (`packages/config`) and domain package skeleton (zod schemas, enums, sample fixtures).
+
+### Milestone B — Domain & Storage Foundations (Days 2-3)
+1. Define domain models: Team, Member, TaskTemplate, TaskTemplateVersion, SubTaskTemplate, Task, SubTaskInstance, Assignment, CalendarEntry.
+2. Implement repository interfaces & in-memory storage using zustand-like store or simple Maps with CRUD operations.
+3. Add tRPC router scaffolding for templates, tasks, teams, calendar, status summary; connect to in-memory adapter.
+4. Seed sample data for manual testing and storybook-like preview states.
+
+### Milestone C — UI Shell & Navigation (Day 3)
+1. Build app layout with sidebar (teams, navigation), header (week selector, filters) using shadcn components.
+2. Implement routing structure: `/` dashboard, `/templates`, `/tasks`, `/calendar`.
+3. Integrate TanStack Query hooks wrapping tRPC calls; provide loading/error skeletons.
+
+### Milestone D — Template Management (Days 4-5)
+1. Template list page with cards/table showing versions and actions (Create, Publish, Archive).
+2. Template builder wizard using shadcn `Stepper` pattern: metadata, sub-tasks, review/publish.
+3. Client-side validation via zod + react-hook-form; enforce at least one sub-task before publish.
+4. API routes enabling versioning (clone/create new version) and immutability of published versions.
+
+### Milestone E — Task Assignment & Execution (Days 6-7)
+1. Task creation form with template selection, team/date/location pickers, priority, duration, notes.
+2. Task detail view with sub-task checklist (mobile-first) allowing completion, blockers, attachments (mock uploader).
+3. Enforce domain rules: required sub-tasks must be completed, status transitions (Not Started → In Progress → Blocked/Done/Cancelled).
+4. Implement team queue view showing tasks grouped by day with progress indicators.
+
+### Milestone F — Weekly Calendar & Status (Days 8-9)
+1. Calendar grid (teams as rows, days as columns) with draggable cards placeholder (read-only for MVP).
+2. Filters for team, location, task type, status; integrate with tRPC queries.
+3. Task detail drawer from calendar card with quick actions (change status, view sub-task progress).
+4. Status summary widgets (completion rate, blockers) on dashboard using aggregation utilities.
+
+### Milestone G — Testing & Documentation (Day 10)
+1. Unit tests for domain logic (versioning, status transitions) using Vitest.
+2. Component tests with Testing Library / Playwright smoke test for critical flows.
+3. Update README with setup (pnpm, Next dev), testing commands, and architecture overview.
+4. Prepare seed script and instructions for future persistence swap.
+
+## 4. Risks & Mitigations
+- **Scope Creep:** Stick to read-only calendar interactions for MVP; document future drag/drop plans.
+- **State Management Complexity:** Use TanStack Query + server mutations to avoid duplicated client state; centralize business logic in domain package.
+- **shadcn Customization Overhead:** Start with default tokens, extend gradually; document any overrides.
+- **Testing Flakiness:** Favor deterministic in-memory fixtures; isolate UI component tests with mock tRPC handlers.
+
+## 5. Open Questions
+- Which auth provider will eventually back the app (Supabase, Auth0, custom)?
+- Do attachments require actual object storage integration in MVP or can we stub uploads until Phase 2?
+- How granular should calendar conflict detection be (per team per day vs. per time slot)?
+- Should teams have configurable capacity thresholds during MVP or is monitoring sufficient?

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# Codextry
+# Beekeeper Task Manager (Next.js prototype)
+
+A JavaScript reimplementation of the Beekeeper Task Manager prototype built with Next.js 14, shadcn/ui components, React Query, and an in-memory domain/store layer shared across the app.
+
+## Tech stack
+
+- **Next.js 14 (App Router)** with TypeScript
+- **shadcn/ui + Tailwind CSS** for accessible UI primitives
+- **TanStack Query** for client-side data fetching/state
+- **Zod + React Hook Form** for schema-validated forms
+- **Vitest + Testing Library** (initial test scaffold)
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The development server runs at `http://localhost:3000`.
+
+## Available scripts
+
+| Command | Description |
+| --- | --- |
+| `pnpm dev` | Start Next.js in development mode |
+| `pnpm build` | Create an optimized production build |
+| `pnpm start` | Run the production build locally |
+| `pnpm lint` | Run ESLint checks |
+| `pnpm test` | Execute Vitest test suite |
+
+## Project layout
+
+```
+apps/
+  web/               # Next.js application
+packages/
+  domain/            # Shared domain types, zod schemas, seed data
+  storage/           # In-memory repository implementing domain interfaces
+  config/            # Shared tsconfig base
+IMPLEMENTATION_PLAN.md
+README.md
+```
+
+## Feature highlights
+
+- Dashboard tab summarizing weekly completion, blockers, and workload.
+- Template builder for creating new task templates with validated sub-tasks.
+- Assignment board grouped by team with quick completion actions on sub-tasks.
+- Weekly calendar grid showing tasks across teams and days.
+
+## Testing
+
+The project includes Vitest and React Testing Library dependencies. Add tests under `apps/web/src` and run with:
+
+```bash
+pnpm --filter web test
+```

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,0 +1,13 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["next", "next/core-web-vitals"],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+  settings: {
+    next: {
+      rootDir: [__dirname],
+    },
+  },
+};

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@beekeeper/domain": "workspace:*",
+    "@beekeeper/storage": "workspace:*",
+    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.1",
+    "@hookform/resolvers": "^3.9.0",
+    "@tanstack/react-query": "^5.56.2",
+    "@tanstack/react-query-devtools": "^5.56.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
+    "lucide-react": "^0.447.0",
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-hook-form": "^7.52.1",
+    "tailwind-merge": "^2.5.2",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@vitejs/plugin-react": "^4.3.1",
+    "@types/node": "20.16.10",
+    "@types/react": "18.3.5",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.4",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "5.6.3",
+    "vitest": "^2.1.4"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,50 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 0.75rem;
+  --primary: 25 95% 53%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 222.2 47.4% 11.2%;
+  --secondary-foreground: 0 0% 100%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 100%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 47.4% 11.2%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 47.4% 11.2%;
+}
+
+.dark {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 215 20.2% 65.1%;
+  --card: 217.2 32.6% 17.5%;
+  --card-foreground: 210 40% 98%;
+  --popover: 217.2 32.6% 17.5%;
+  --popover-foreground: 210 40% 98%;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+.scrollbar-thin {
+  scrollbar-width: thin;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import { Providers } from "@/components/layout/providers";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Beekeeper Task Manager",
+  description: "Plan, assign, and track apiary work with reusable templates and weekly calendars.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={inter.className}>
+        <Providers>
+          <div className="min-h-screen bg-background">
+            {children}
+          </div>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,38 @@
+import { CalendarView } from "@/features/calendar/calendar-grid";
+import { DashboardOverview } from "@/features/dashboard/dashboard-overview";
+import { TaskBoard } from "@/features/tasks/task-board";
+import { TemplateManager } from "@/features/templates/template-manager";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-7xl space-y-6 px-6 py-10">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Beekeeper Task Manager</h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+          Coordinate apiary teams with reusable templates, consistent assignments, and a weekly schedule overview.
+        </p>
+      </div>
+      <Tabs defaultValue="dashboard" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+          <TabsTrigger value="templates">Templates</TabsTrigger>
+          <TabsTrigger value="tasks">Assignments</TabsTrigger>
+          <TabsTrigger value="calendar">Calendar</TabsTrigger>
+        </TabsList>
+        <TabsContent value="dashboard" className="space-y-6">
+          <DashboardOverview />
+        </TabsContent>
+        <TabsContent value="templates" className="space-y-6">
+          <TemplateManager />
+        </TabsContent>
+        <TabsContent value="tasks" className="space-y-6">
+          <TaskBoard />
+        </TabsContent>
+        <TabsContent value="calendar" className="space-y-6">
+          <CalendarView />
+        </TabsContent>
+      </Tabs>
+    </main>
+  );
+}

--- a/apps/web/src/components/layout/providers.tsx
+++ b/apps/web/src/components/layout/providers.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+        success: "border-transparent bg-green-100 text-green-900",
+        warning: "border-transparent bg-amber-100 text-amber-900",
+        info: "border-transparent bg-blue-100 text-blue-900",
+        destructive: "border-transparent bg-red-100 text-red-900",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref as any}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border border-border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  ),
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn("fixed inset-0 z-50 bg-black/40 backdrop-blur-sm", className)}
+      {...props}
+    />
+  ),
+);
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-popover p-6 shadow-lg duration-200",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ),
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+);
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  ),
+);
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+};

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = "text", ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
+
+const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>>(
+  ({ className, ...props }, ref) => (
+    <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+  ),
+);
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+    <div
+      ref={ref}
+      role={decorative ? "none" : "separator"}
+      aria-orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <SheetPrimitive.Overlay
+      ref={ref}
+      className={cn("fixed inset-0 z-50 bg-black/40 backdrop-blur-sm", className)}
+      {...props}
+    />
+  ),
+);
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md flex-col border-l border-border bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-slide-out-to-right data-[state=open]:animate-slide-in-from-right",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  ),
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("mt-auto flex flex-col gap-2", className)} {...props} />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Title>, React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+  ),
+);
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Description>, React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>>(
+  ({ className, ...props }, ref) => (
+    <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  ),
+);
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className }: { className: string }) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} />;
+}
+
+export { Skeleton };

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  ),
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  ),
+);
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+  ),
+);
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn("bg-muted font-medium text-muted-foreground", className)} {...props} />
+  ),
+);
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th ref={ref} className={cn("h-10 px-2 text-left align-middle font-medium text-muted-foreground", className)} {...props} />
+  ),
+);
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn("p-2 align-middle", className)} {...props} />
+  ),
+);
+TableCell.displayName = "TableCell";
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell };

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<React.ElementRef<typeof TabsPrimitive.List>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.List ref={ref} className={cn("inline-flex items-center justify-center rounded-md bg-muted p-1 text-muted-foreground", className)} {...props} />
+  ),
+);
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "inline-flex min-w-[120px] items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Content>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
+        "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/web/src/features/calendar/calendar-grid.tsx
+++ b/apps/web/src/features/calendar/calendar-grid.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { addDays, addWeeks, format, startOfWeek } from "date-fns";
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+import { fetchCalendar, fetchTeams, fetchTemplates } from "@/lib/data-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function CalendarView() {
+  const [weekStart, setWeekStart] = useState(startOfWeek(new Date(), { weekStartsOn: 1 }));
+  const { data: calendar, isLoading } = useQuery({
+    queryKey: ["calendar", weekStart.toISOString()],
+    queryFn: () => fetchCalendar(weekStart),
+  });
+  const { data: teams } = useQuery({ queryKey: ["teams"], queryFn: fetchTeams });
+  const { data: templates } = useQuery({ queryKey: ["templates"], queryFn: fetchTemplates });
+
+  const columns = useMemo(() => {
+    return Array.from({ length: 7 }).map((_, index) => addDays(weekStart, index));
+  }, [weekStart]);
+
+  const cellsByTeam = useMemo(() => {
+    if (!calendar) return {} as Record<string, typeof calendar.cells>;
+    return calendar.cells.reduce<Record<string, typeof calendar.cells>>((acc, cell) => {
+      acc[cell.teamId] = acc[cell.teamId] ? [...acc[cell.teamId], cell] : [cell];
+      return acc;
+    }, {});
+  }, [calendar]);
+
+  const updateWeek = (direction: "prev" | "next") => {
+    setWeekStart((prev) => addWeeks(prev, direction === "next" ? 1 : -1));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">Weekly calendar</h2>
+          <p className="text-sm text-muted-foreground">View team assignments by day to spot coverage gaps.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={() => updateWeek("prev")}
+            aria-label="Previous week">
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Badge variant="info" className="gap-1">
+            <CalendarDays className="h-4 w-4" />
+            {calendar ? calendar.label : format(weekStart, "MMM d")}
+          </Badge>
+          <Button variant="ghost" size="icon" onClick={() => updateWeek("next")}
+            aria-label="Next week">
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <CardTitle className="text-lg">Team schedule</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          {isLoading || !calendar ? (
+            <Skeleton className="h-64 w-full" />
+          ) : (
+            <div className="min-w-[900px]">
+              <div className="grid grid-cols-[200px_repeat(7,1fr)] border border-border text-sm">
+                <div className="sticky left-0 z-10 bg-muted/40 p-3 font-semibold">Team</div>
+                {columns.map((date, index) => (
+                  <div key={index} className="border-l border-border p-3 text-center font-semibold">
+                    <p>{format(date, "EEE")}</p>
+                    <p className="text-xs text-muted-foreground">{format(date, "MMM d")}</p>
+                  </div>
+                ))}
+                {(teams ?? []).map((team) => (
+                  <React.Fragment key={team.id}>
+                    <div className="border-t border-border bg-muted/20 p-3 font-medium">{team.name}</div>
+                    {columns.map((date, index) => {
+                      const dayCells = (cellsByTeam[team.id] ?? []).filter((cell) =>
+                        format(new Date(cell.date), "yyyy-MM-dd") === format(date, "yyyy-MM-dd"),
+                      );
+                      return (
+                        <div key={`${team.id}-${index}`} className="border-l border-t border-border p-3">
+                          <div className="flex flex-col gap-2">
+                            {dayCells.length === 0 && <p className="text-xs text-muted-foreground">No assignments</p>}
+                            {dayCells.flatMap((cell) => cell.tasks).map((task) => (
+                              <div key={task.id} className="rounded-md border border-border bg-card/60 p-2 shadow-sm">
+                                <p className="text-sm font-medium">
+                                  {templates?.find((template) => template.currentVersion.id === task.templateVersionId)?.name ??
+                                    "Task"}
+                                </p>
+                                <p className="text-xs text-muted-foreground">{task.location}</p>
+                                <Badge variant="outline" className="mt-1 w-max text-xs capitalize">
+                                  {task.status.replace("_", " ")}
+                                </Badge>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </React.Fragment>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/dashboard-overview.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { Activity, AlertCircle, CalendarRange } from "lucide-react";
+
+import { fetchStatusSummary } from "@/lib/data-client";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function DashboardOverview() {
+  const { data, isLoading } = useQuery({ queryKey: ["status"], queryFn: () => fetchStatusSummary() });
+
+  if (isLoading || !data) {
+    return <DashboardSkeleton />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {data.map((summary) => (
+          <Card key={summary.teamId}>
+            <CardHeader className="pb-2">
+              <CardDescription>{summary.teamId.replace("team-", "Team ").toUpperCase()}</CardDescription>
+              <CardTitle className="text-3xl font-bold">{summary.completionRate}%</CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0 text-sm text-muted-foreground">
+              <p>Scheduled: {summary.scheduled}</p>
+              <p>In progress: {summary.inProgress}</p>
+              <p>Blockers: {summary.blockers}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle className="text-lg">Operational Highlights</CardTitle>
+            <CardDescription>Week of {format(new Date(data[0].weekStart), "MMM d, yyyy")}</CardDescription>
+          </div>
+          <Badge variant="info" className="gap-1">
+            <CalendarRange className="h-4 w-4" />
+            {format(new Date(data[0].weekStart), "MMM d")}
+            {" – "}
+            {format(new Date(data[0].weekEnd), "MMM d")}
+          </Badge>
+        </CardHeader>
+        <CardContent className="grid gap-6 lg:grid-cols-3">
+          <Insight
+            icon={<Activity className="h-5 w-5 text-emerald-500" />}
+            label="Average completion"
+            value={`${Math.round(data.reduce((acc, item) => acc + item.completionRate, 0) / data.length)}%`}
+            description="Teams are on track for the week."
+          />
+          <Insight
+            icon={<AlertCircle className="h-5 w-5 text-amber-500" />}
+            label="Blockers"
+            value={`${data.reduce((acc, item) => acc + item.blockers, 0)} tasks`}
+            description="Follow up with mobile support on vehicle maintenance."
+          />
+          <Insight
+            icon={<CalendarRange className="h-5 w-5 text-sky-500" />}
+            label="Active schedules"
+            value={`${data.reduce((acc, item) => acc + item.scheduled, 0)} tasks`}
+            description="North Apiary leading with highest task load."
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Insight({ icon, label, value, description }: { icon: React.ReactNode; label: string; value: string; description: string }) {
+  return (
+    <div className="flex items-start gap-4 rounded-lg border border-border p-4">
+      <div className="rounded-md bg-accent p-2 text-accent-foreground">{icon}</div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">{label}</p>
+        <p className="text-2xl font-semibold">{value}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-32 w-full rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-72 w-full rounded-lg" />
+    </div>
+  );
+}

--- a/apps/web/src/features/tasks/task-board.tsx
+++ b/apps/web/src/features/tasks/task-board.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { ClipboardCheck, ListChecks, MapPin, Plus } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { taskDraftSchema } from "@beekeeper/domain";
+import { createTask, fetchTasks, fetchTeams, fetchTemplates, completeSubTask } from "@/lib/data-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const priorityColor: Record<string, "default" | "warning" | "success" | "info" | "destructive"> = {
+  low: "default",
+  medium: "info",
+  high: "warning",
+  urgent: "destructive",
+};
+
+export function TaskBoard() {
+  const queryClient = useQueryClient();
+  const { data: tasks } = useQuery({ queryKey: ["tasks"], queryFn: fetchTasks });
+  const { data: templates } = useQuery({ queryKey: ["templates"], queryFn: fetchTemplates });
+  const { data: teams } = useQuery({ queryKey: ["teams"], queryFn: fetchTeams });
+
+  const [open, setOpen] = useState(false);
+
+  const form = useForm<z.infer<typeof taskDraftSchema>>({
+    resolver: zodResolver(taskDraftSchema),
+    defaultValues: {
+      templateId: templates?.[0]?.id ?? "",
+      teamId: teams?.[0]?.id ?? "",
+      startDate: new Date().toISOString().slice(0, 10),
+      location: "Evergreen Yard",
+      priority: "medium",
+      notes: "",
+    },
+  });
+
+  const createTaskMutation = useMutation({
+    mutationFn: createTask,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      setOpen(false);
+    },
+  });
+
+  useEffect(() => {
+    if (templates && templates.length > 0 && !form.getValues("templateId")) {
+      form.setValue("templateId", templates[0].id);
+    }
+  }, [templates, form]);
+
+  useEffect(() => {
+    if (teams && teams.length > 0 && !form.getValues("teamId")) {
+      form.setValue("teamId", teams[0].id);
+    }
+  }, [teams, form]);
+
+  const completeSubTaskMutation = useMutation({
+    mutationFn: ({ taskId, subTaskId }: { taskId: string; subTaskId: string }) => completeSubTask(taskId, subTaskId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+  });
+
+  const groupedTasks = useMemo(() => {
+    if (!tasks) return {} as Record<string, typeof tasks>;
+    return tasks.reduce<Record<string, typeof tasks>>((acc, task) => {
+      acc[task.teamId] = acc[task.teamId] ? [...acc[task.teamId], task] : [task];
+      return acc;
+    }, {});
+  }, [tasks]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Assignments</h2>
+          <p className="text-sm text-muted-foreground">Assign templated work to teams and track progress.</p>
+        </div>
+        <Button className="gap-2" onClick={() => setOpen(true)}>
+          <Plus className="h-4 w-4" /> New assignment
+        </Button>
+      </div>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Assign a task</SheetTitle>
+            <SheetDescription>Select a template, team, and schedule details.</SheetDescription>
+          </SheetHeader>
+          <form
+            className="space-y-4"
+            onSubmit={form.handleSubmit((values) => createTaskMutation.mutate(values))}
+          >
+            <div className="space-y-2">
+              <Label htmlFor="templateId">Template</Label>
+              <select
+                id="templateId"
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register("templateId")}
+              >
+                {(templates ?? []).map((template) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name} (v{template.currentVersion.version})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="teamId">Team</Label>
+              <select
+                id="teamId"
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register("teamId")}
+              >
+                {(teams ?? []).map((team) => (
+                  <option key={team.id} value={team.id}>
+                    {team.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="startDate">Scheduled date</Label>
+              <Input id="startDate" type="date" {...form.register("startDate")} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Input id="location" placeholder="Evergreen Yard" {...form.register("location")} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="priority">Priority</Label>
+              <select
+                id="priority"
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register("priority")}
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="urgent">Urgent</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea id="notes" placeholder="Add context or blockers" {...form.register("notes")} />
+            </div>
+            <SheetFooter>
+              <Button type="submit" disabled={createTaskMutation.isPending}>
+                {createTaskMutation.isPending ? "Assigning..." : "Create assignment"}
+              </Button>
+            </SheetFooter>
+          </form>
+        </SheetContent>
+      </Sheet>
+      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        {Object.entries(groupedTasks).map(([teamId, teamTasks]) => (
+          <Card key={teamId} className="flex flex-col">
+            <CardHeader className="space-y-2">
+              <CardTitle>{teams?.find((team) => team.id === teamId)?.name ?? teamId}</CardTitle>
+              <CardDescription>{teamTasks.length} scheduled tasks</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {teamTasks.map((task) => (
+                <div key={task.id} className="rounded-lg border border-border p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-semibold">{templates?.find((t) => t.currentVersion.id === task.templateVersionId)?.name ?? task.id}</p>
+                      <p className="text-sm text-muted-foreground">
+                        Scheduled {format(new Date(task.assignedOn), "MMM d")} • {task.location}
+                      </p>
+                    </div>
+                    <Badge variant={priorityColor[task.priority] ?? "default"}>{task.priority}</Badge>
+                  </div>
+                  <Table className="mt-4">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Sub-task</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {task.subTasks.map((subTask) => (
+                        <TableRow key={subTask.id}>
+                          <TableCell className="font-medium">{subTask.label}</TableCell>
+                          <TableCell>{subTask.status === "complete" ? "Complete" : "Pending"}</TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={subTask.status === "complete"}
+                              onClick={() => completeSubTaskMutation.mutate({ taskId: task.id, subTaskId: subTask.id })}
+                            >
+                              Mark done
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ))}
+            </CardContent>
+            <CardFooter className="justify-end text-xs text-muted-foreground">
+              Updated {format(new Date(teamTasks[0].assignedOn), "MMM d, yyyy")}
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+      {tasks && tasks.length === 0 && (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            No assignments yet. Use the “New assignment” button to schedule work.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/templates/template-manager.tsx
+++ b/apps/web/src/features/templates/template-manager.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+import { z } from "zod";
+
+import { templateDraftSchema } from "@beekeeper/domain";
+import { createTemplate, fetchTemplates } from "@/lib/data-client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const defaultValues: z.infer<typeof templateDraftSchema> = {
+  name: "Spring Inspection",
+  description: "Seasonal inspection template",
+  expectedDurationMinutes: 120,
+  defaultLocationType: "yard",
+  subTasks: [
+    { label: "Inspect brood frames", description: "Check brood health", inputType: "checkbox", required: true },
+  ],
+};
+
+export function TemplateManager() {
+  const queryClient = useQueryClient();
+  const { data: templates, isLoading } = useQuery({ queryKey: ["templates"], queryFn: fetchTemplates });
+  const [open, setOpen] = useState(false);
+
+  const form = useForm<z.infer<typeof templateDraftSchema>>({
+    resolver: zodResolver(templateDraftSchema),
+    defaultValues,
+  });
+
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: "subTasks" });
+
+  const mutation = useMutation({
+    mutationFn: createTemplate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["templates"] });
+      setOpen(false);
+      form.reset(defaultValues);
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Task Templates</h2>
+          <p className="text-sm text-muted-foreground">Standardize recurring apiary work with reusable checklists.</p>
+        </div>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" /> New template
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-3xl overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Create a task template</DialogTitle>
+              <DialogDescription>Define metadata and default sub-tasks. Published versions are immutable.</DialogDescription>
+            </DialogHeader>
+            <form
+              className="space-y-6"
+              onSubmit={form.handleSubmit((values) => mutation.mutate(values))}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input id="name" placeholder="Spring Inspection" {...form.register("name")} />
+                  {form.formState.errors.name && (
+                    <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="expectedDurationMinutes">Duration (minutes)</Label>
+                  <Input
+                    id="expectedDurationMinutes"
+                    type="number"
+                    min={0}
+                    {...form.register("expectedDurationMinutes", { valueAsNumber: true })}
+                  />
+                  {form.formState.errors.expectedDurationMinutes && (
+                    <p className="text-xs text-destructive">{form.formState.errors.expectedDurationMinutes.message}</p>
+                  )}
+                </div>
+                <div className="space-y-2 md:col-span-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea id="description" placeholder="What does this template cover?" {...form.register("description")} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="defaultLocationType">Default location type</Label>
+                  <select
+                    id="defaultLocationType"
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    {...form.register("defaultLocationType")}
+                  >
+                    <option value="yard">Yard</option>
+                    <option value="beehome">BeeHome</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-lg font-medium">Sub-tasks</h3>
+                    <p className="text-sm text-muted-foreground">Add checklist items and validations.</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="gap-2"
+                    onClick={() =>
+                      append({ label: "", description: "", inputType: "checkbox", required: false })
+                    }
+                  >
+                    <Sparkles className="h-4 w-4" /> Add sub-task
+                  </Button>
+                </div>
+                <div className="space-y-4">
+                  {fields.map((field, index) => (
+                    <div key={field.id} className="rounded-lg border border-border p-4">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor={`subtask-${index}-label`}>Label</Label>
+                          <Input
+                            id={`subtask-${index}-label`}
+                            placeholder="Inspect brood frames"
+                            {...form.register(`subTasks.${index}.label` as const)}
+                          />
+                          {form.formState.errors.subTasks?.[index]?.label && (
+                            <p className="text-xs text-destructive">
+                              {form.formState.errors.subTasks?.[index]?.label?.message}
+                            </p>
+                          )}
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`subtask-${index}-inputType`}>Input type</Label>
+                          <select
+                            id={`subtask-${index}-inputType`}
+                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            {...form.register(`subTasks.${index}.inputType` as const)}
+                          >
+                            <option value="checkbox">Checkbox</option>
+                            <option value="number">Number</option>
+                            <option value="text">Text</option>
+                            <option value="photo">Photo</option>
+                          </select>
+                        </div>
+                        <div className="space-y-2 md:col-span-2">
+                          <Label htmlFor={`subtask-${index}-description`}>Description</Label>
+                          <Textarea
+                            id={`subtask-${index}-description`}
+                            placeholder="Guidance or validation hints"
+                            {...form.register(`subTasks.${index}.description` as const)}
+                          />
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <input
+                            id={`subtask-${index}-required`}
+                            type="checkbox"
+                            className="h-4 w-4 rounded border border-input"
+                            {...form.register(`subTasks.${index}.required` as const)}
+                          />
+                          <Label htmlFor={`subtask-${index}-required`} className="text-sm">
+                            Required to complete task
+                          </Label>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="justify-self-end text-destructive"
+                          onClick={() => remove(index)}
+                          disabled={fields.length <= 1}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                {form.formState.errors.subTasks && (
+                  <p className="text-xs text-destructive">{form.formState.errors.subTasks.message as string}</p>
+                )}
+              </div>
+              <DialogFooter>
+                <Button type="submit" disabled={mutation.isPending}>
+                  {mutation.isPending ? "Saving..." : "Publish template"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {(templates ?? []).map((template) => (
+          <Card key={template.id} className="flex flex-col">
+            <CardHeader>
+              <CardTitle>{template.name}</CardTitle>
+              <CardDescription>
+                {template.currentVersion.description ?? "No description provided."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center gap-2 text-sm">
+                <Badge variant="info">v{template.currentVersion.version}</Badge>
+                <span>{template.currentVersion.subTasks.length} sub-tasks</span>
+                <span>• {template.currentVersion.expectedDurationMinutes} min</span>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Label</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Required</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {template.currentVersion.subTasks.map((subTask) => (
+                    <TableRow key={subTask.id}>
+                      <TableCell className="font-medium">{subTask.label}</TableCell>
+                      <TableCell className="capitalize">{subTask.inputType}</TableCell>
+                      <TableCell>{subTask.required ? "Yes" : "No"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading templates...</p>}
+      {!isLoading && (templates?.length ?? 0) === 0 && (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            No templates yet. Create your first reusable checklist to get started.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-client.ts
+++ b/apps/web/src/lib/data-client.ts
@@ -1,0 +1,35 @@
+import { startOfWeek } from "date-fns";
+import { store } from "@beekeeper/storage";
+import type { TaskDraft, TemplateDraft } from "@beekeeper/domain";
+
+export async function fetchTeams() {
+  return store.listTeams();
+}
+
+export async function fetchTemplates() {
+  return store.listTemplates();
+}
+
+export async function fetchTasks() {
+  return store.listTasks();
+}
+
+export async function fetchStatusSummary(weekStart = startOfWeek(new Date(), { weekStartsOn: 1 })) {
+  return store.getStatusSummary(weekStart);
+}
+
+export async function fetchCalendar(weekStart = startOfWeek(new Date(), { weekStartsOn: 1 })) {
+  return store.getCalendar(weekStart);
+}
+
+export async function createTemplate(draft: TemplateDraft) {
+  return store.createTemplate(draft);
+}
+
+export async function createTask(draft: TaskDraft) {
+  return store.createTask(draft);
+}
+
+export async function completeSubTask(taskId: string, subTaskId: string) {
+  return store.updateSubTask(taskId, subTaskId, { status: "complete" });
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,78 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+      },
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/app/*": ["./src/app/*"],
+      "@beekeeper/domain": ["../../packages/domain/src"],
+      "@beekeeper/storage": ["../../packages/storage/src"]
+    },
+    "allowJs": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["next-env.d.ts", "src/**/*", "vitest.setup.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "beekeeper-task-manager",
+  "private": true,
+  "version": "0.1.0",
+  "packageManager": "pnpm@10.5.2",
+  "scripts": {
+    "dev": "pnpm --filter web dev",
+    "build": "pnpm --filter web build",
+    "lint": "pnpm --filter web lint",
+    "test": "pnpm lint && pnpm --filter web test"
+  }
+}

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@beekeeper/domain",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,374 @@
+import { addDays, eachDayOfInterval, endOfWeek, formatISO, isWithinInterval, startOfWeek } from "date-fns";
+import { z } from "zod";
+
+export const taskStatusSchema = z.enum([
+  "not_started",
+  "in_progress",
+  "blocked",
+  "done",
+  "cancelled",
+]);
+export type TaskStatus = z.infer<typeof taskStatusSchema>;
+
+export const prioritySchema = z.enum(["low", "medium", "high", "urgent"]);
+export type Priority = z.infer<typeof prioritySchema>;
+
+export const inputTypeSchema = z.enum(["checkbox", "number", "text", "photo"]);
+export type InputType = z.infer<typeof inputTypeSchema>;
+
+export interface Team {
+  id: string;
+  name: string;
+  coverage: string;
+}
+
+export interface Member {
+  id: string;
+  name: string;
+  role: "manager" | "beekeeper";
+  teamId?: string;
+}
+
+export interface SubTaskTemplate {
+  id: string;
+  label: string;
+  description?: string;
+  inputType: InputType;
+  required: boolean;
+  defaultTarget?: string | number;
+}
+
+export interface TaskTemplateVersion {
+  id: string;
+  templateId: string;
+  version: number;
+  name: string;
+  description?: string;
+  expectedDurationMinutes: number;
+  defaultLocationType: "yard" | "beehome" | "other";
+  subTasks: SubTaskTemplate[];
+  publishedAt: string;
+}
+
+export interface TaskTemplate {
+  id: string;
+  name: string;
+  archived: boolean;
+  currentVersion: TaskTemplateVersion;
+  previousVersions: TaskTemplateVersion[];
+}
+
+export interface SubTaskInstance {
+  id: string;
+  templateId: string;
+  label: string;
+  description?: string;
+  inputType: InputType;
+  required: boolean;
+  target?: string | number;
+  status: "pending" | "complete";
+  notes?: string;
+  blocker?: string;
+}
+
+export interface Task {
+  id: string;
+  templateVersionId: string;
+  teamId: string;
+  assignedOn: string;
+  dueOn: string;
+  priority: Priority;
+  location: string;
+  status: TaskStatus;
+  notes?: string;
+  subTasks: SubTaskInstance[];
+}
+
+export interface CalendarCell {
+  date: string;
+  teamId: string;
+  tasks: Task[];
+}
+
+export interface StatusSummary {
+  teamId: string;
+  weekStart: string;
+  weekEnd: string;
+  completionRate: number;
+  blockers: number;
+  inProgress: number;
+  scheduled: number;
+}
+
+export interface SeedData {
+  teams: Team[];
+  members: Member[];
+  templates: TaskTemplate[];
+  tasks: Task[];
+}
+
+export const SEED_START = startOfWeek(new Date(), { weekStartsOn: 1 });
+
+const templateVersion = (templateId: string, version: number, overrides?: Partial<TaskTemplateVersion>): TaskTemplateVersion => ({
+  id: `${templateId}-v${version}`,
+  templateId,
+  version,
+  name: overrides?.name ?? "Spring Inspection",
+  description:
+    overrides?.description ??
+    "Seasonal inspection covering brood frames, mite treatment, and queen assessment.",
+  expectedDurationMinutes: overrides?.expectedDurationMinutes ?? 180,
+  defaultLocationType: overrides?.defaultLocationType ?? "yard",
+  subTasks:
+    overrides?.subTasks ??
+    [
+      {
+        id: `${templateId}-st1`,
+        label: "Inspect brood frames",
+        description: "Confirm brood pattern health",
+        inputType: "checkbox",
+        required: true,
+      },
+      {
+        id: `${templateId}-st2`,
+        label: "Varroa mite count",
+        description: "Record sticky board mite count",
+        inputType: "number",
+        required: true,
+        defaultTarget: 3,
+      },
+      {
+        id: `${templateId}-st3`,
+        label: "Queen status",
+        description: "Note queen temperament and laying pattern",
+        inputType: "text",
+        required: false,
+      },
+    ],
+  publishedAt: overrides?.publishedAt ?? formatISO(SEED_START),
+});
+
+const defaultTemplate: TaskTemplate = {
+  id: "template-spring-inspection",
+  name: "Spring Inspection",
+  archived: false,
+  currentVersion: templateVersion("template-spring-inspection", 2, {
+    version: 2,
+    name: "Spring Inspection v2",
+    subTasks: [
+      {
+        id: "template-spring-inspection-st1",
+        label: "Inspect brood frames",
+        inputType: "checkbox",
+        required: true,
+      },
+      {
+        id: "template-spring-inspection-st2",
+        label: "Varroa mite count",
+        inputType: "number",
+        required: true,
+        defaultTarget: 2,
+      },
+      {
+        id: "template-spring-inspection-st3",
+        label: "Record queen health",
+        inputType: "text",
+        required: false,
+      },
+    ],
+  }),
+  previousVersions: [templateVersion("template-spring-inspection", 1)],
+};
+
+const pollinationTemplate: TaskTemplate = {
+  id: "template-pollination-check",
+  name: "Pollination Readiness",
+  archived: false,
+  currentVersion: templateVersion("template-pollination-check", 1, {
+    name: "Pollination Readiness",
+    description: "Ensure hives are ready for pollination contracts.",
+    subTasks: [
+      {
+        id: "template-pollination-check-st1",
+        label: "Check nectar stores",
+        inputType: "number",
+        required: true,
+        defaultTarget: 40,
+      },
+      {
+        id: "template-pollination-check-st2",
+        label: "Confirm hive strength",
+        inputType: "text",
+        required: true,
+      },
+    ],
+  }),
+  previousVersions: [],
+};
+
+const teams: Team[] = [
+  { id: "team-north", name: "North Apiary", coverage: "Cascade Foothills" },
+  { id: "team-south", name: "South Apiary", coverage: "Valley Orchards" },
+  { id: "team-mobile", name: "Mobile Support", coverage: "Statewide" },
+];
+
+const members: Member[] = [
+  { id: "manager-1", name: "Jules Kim", role: "manager" },
+  { id: "beekeeper-1", name: "Mara Singh", role: "beekeeper", teamId: "team-north" },
+  { id: "beekeeper-2", name: "Rafi Patel", role: "beekeeper", teamId: "team-south" },
+  { id: "beekeeper-3", name: "Colin Abara", role: "beekeeper", teamId: "team-mobile" },
+];
+
+const createTaskFromTemplate = (
+  id: string,
+  template: TaskTemplate,
+  teamId: string,
+  offsetDays: number,
+  overrides?: Partial<Task>
+): Task => {
+  const assignedOn = addDays(SEED_START, offsetDays);
+  const dueOn = addDays(assignedOn, overrides?.dueOn ? 0 : 0);
+  const subTasks: SubTaskInstance[] = template.currentVersion.subTasks.map((st, index) => ({
+    id: `${id}-sub-${index}`,
+    templateId: st.id,
+    label: st.label,
+    description: st.description,
+    inputType: st.inputType,
+    required: st.required,
+    target: st.defaultTarget,
+    status: "pending",
+  }));
+
+  return {
+    id,
+    templateVersionId: template.currentVersion.id,
+    teamId,
+    assignedOn: formatISO(assignedOn),
+    dueOn: formatISO(addDays(assignedOn, overrides?.dueOn ? Number(overrides.dueOn) : 0)),
+    priority: overrides?.priority ?? "medium",
+    location: overrides?.location ?? "Evergreen Yard",
+    status: overrides?.status ?? "not_started",
+    notes: overrides?.notes,
+    subTasks,
+  };
+};
+
+const tasks: Task[] = [
+  createTaskFromTemplate("task-1", defaultTemplate, "team-north", 0, {
+    status: "in_progress",
+    location: "Evergreen Yard",
+  }),
+  createTaskFromTemplate("task-2", defaultTemplate, "team-south", 1, {
+    status: "not_started",
+    location: "Valley Orchard 4",
+    priority: "high",
+  }),
+  createTaskFromTemplate("task-3", pollinationTemplate, "team-mobile", 2, {
+    status: "blocked",
+    notes: "Vehicle maintenance",
+  }),
+  createTaskFromTemplate("task-4", pollinationTemplate, "team-north", 4, {
+    status: "not_started",
+    location: "Blueberry Farm",
+  }),
+];
+
+export const seedData: SeedData = {
+  teams,
+  members,
+  templates: [defaultTemplate, pollinationTemplate],
+  tasks,
+};
+
+export const calculateTaskProgress = (task: Task): number => {
+  if (task.subTasks.length === 0) return 0;
+  const completed = task.subTasks.filter((subTask) => subTask.status === "complete").length;
+  return Math.round((completed / task.subTasks.length) * 100);
+};
+
+export const deriveTaskStatus = (task: Task): TaskStatus => {
+  if (task.status === "cancelled" || task.status === "blocked") {
+    return task.status;
+  }
+  const completed = task.subTasks.every((subTask) => subTask.status === "complete");
+  if (completed) {
+    return "done";
+  }
+  const started = task.subTasks.some((subTask) => subTask.status === "complete");
+  return started ? "in_progress" : "not_started";
+};
+
+export const createStatusSummary = (tasksForTeam: Task[], teamId: string, weekStart: Date): StatusSummary => {
+  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 });
+  const filtered = tasksForTeam.filter((task) =>
+    isWithinInterval(new Date(task.assignedOn), { start: weekStart, end: weekEnd })
+  );
+  const blockers = filtered.filter((task) => task.status === "blocked").length;
+  const done = filtered.filter((task) => deriveTaskStatus(task) === "done").length;
+  const inProgress = filtered.filter((task) => task.status === "in_progress").length;
+  const completionRate = filtered.length === 0 ? 0 : Math.round((done / filtered.length) * 100);
+  return {
+    teamId,
+    weekStart: formatISO(weekStart),
+    weekEnd: formatISO(weekEnd),
+    completionRate,
+    blockers,
+    inProgress,
+    scheduled: filtered.length,
+  };
+};
+
+export interface CalendarViewOptions {
+  weekStart?: Date;
+}
+
+export const buildCalendarMatrix = (tasksData: Task[], options: CalendarViewOptions = {}): CalendarCell[] => {
+  const weekStart = options.weekStart ?? startOfWeek(new Date(), { weekStartsOn: 1 });
+  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 });
+  const weekDays = eachDayOfInterval({ start: weekStart, end: weekEnd });
+
+  const cells: CalendarCell[] = [];
+  for (const team of teams) {
+    for (const day of weekDays) {
+      const dayTasks = tasksData.filter((task) => {
+        return task.teamId === team.id && isWithinInterval(new Date(task.assignedOn), { start: day, end: endOfWeek(day, { weekStartsOn: 1 }) }) && formatISO(day).slice(0, 10) === formatISO(new Date(task.assignedOn)).slice(0, 10);
+      });
+      cells.push({ date: formatISO(day), teamId: team.id, tasks: dayTasks });
+    }
+  }
+  return cells;
+};
+
+export const weekRangeLabel = (weekStart: Date): string => {
+  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 });
+  return `${weekStart.toLocaleDateString(undefined, { month: "short", day: "numeric" })} – ${weekEnd.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+};
+
+export type TemplateDraft = z.infer<typeof templateDraftSchema>;
+
+export const templateDraftSchema = z.object({
+  name: z.string().min(3, "Name is required"),
+  description: z.string().optional(),
+  expectedDurationMinutes: z.number().min(15),
+  defaultLocationType: z.enum(["yard", "beehome", "other"]),
+  subTasks: z
+    .array(
+      z.object({
+        label: z.string().min(1),
+        description: z.string().optional(),
+        inputType: inputTypeSchema,
+        required: z.boolean(),
+      })
+    )
+    .min(1, "At least one sub-task is required"),
+});
+
+export const taskDraftSchema = z.object({
+  templateId: z.string(),
+  teamId: z.string(),
+  startDate: z.string(),
+  location: z.string().min(1),
+  priority: prioritySchema,
+  notes: z.string().optional(),
+});
+export type TaskDraft = z.infer<typeof taskDraftSchema>;

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@beekeeper/storage",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@beekeeper/domain": "workspace:*",
+    "nanoid": "^5.0.7"
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,175 @@
+import { addDays, formatISO, startOfWeek } from "date-fns";
+import { nanoid } from "nanoid";
+import {
+  SeedData,
+  Task,
+  TaskDraft,
+  TaskTemplate,
+  TaskTemplateVersion,
+  TemplateDraft,
+  buildCalendarMatrix,
+  calculateTaskProgress,
+  createStatusSummary,
+  seedData,
+  taskDraftSchema,
+  templateDraftSchema,
+  weekRangeLabel,
+} from "@beekeeper/domain";
+
+const cloneTemplateVersion = (template: TaskTemplate): TaskTemplateVersion => {
+  const latest = template.currentVersion;
+  const versionNumber = latest.version + 1;
+  return {
+    ...latest,
+    id: `${template.id}-v${versionNumber}`,
+    version: versionNumber,
+    publishedAt: formatISO(new Date()),
+  };
+};
+
+class InMemoryStore {
+  private data: SeedData;
+
+  constructor(seed: SeedData) {
+    this.data = JSON.parse(JSON.stringify(seed));
+  }
+
+  listTeams() {
+    return structuredClone(this.data.teams);
+  }
+
+  listTemplates() {
+    return structuredClone(this.data.templates);
+  }
+
+  listTasks() {
+    return structuredClone(this.data.tasks);
+  }
+
+  getTemplate(templateId: string) {
+    return this.data.templates.find((template) => template.id === templateId);
+  }
+
+  createTemplate(draft: TemplateDraft) {
+    const parsed = templateDraftSchema.parse(draft);
+    const id = `template-${nanoid(6)}`;
+    const version: TaskTemplateVersion = {
+      id: `${id}-v1`,
+      templateId: id,
+      version: 1,
+      name: parsed.name,
+      description: parsed.description,
+      expectedDurationMinutes: parsed.expectedDurationMinutes,
+      defaultLocationType: parsed.defaultLocationType,
+      subTasks: parsed.subTasks.map((subTask, index) => ({
+        id: `${id}-st-${index + 1}`,
+        label: subTask.label,
+        description: subTask.description,
+        inputType: subTask.inputType,
+        required: subTask.required,
+      })),
+      publishedAt: formatISO(new Date()),
+    };
+
+    const template: TaskTemplate = {
+      id,
+      name: parsed.name,
+      archived: false,
+      currentVersion: version,
+      previousVersions: [],
+    };
+    this.data.templates.push(template);
+    return template;
+  }
+
+  createTemplateVersion(templateId: string) {
+    const template = this.getTemplate(templateId);
+    if (!template) {
+      throw new Error("Template not found");
+    }
+    const nextVersion = cloneTemplateVersion(template);
+    template.previousVersions = [template.currentVersion, ...template.previousVersions];
+    template.currentVersion = nextVersion;
+    return template;
+  }
+
+  createTask(draft: TaskDraft) {
+    const parsed = taskDraftSchema.parse(draft);
+    const template = this.getTemplate(parsed.templateId);
+    if (!template) {
+      throw new Error("Template not found");
+    }
+    const id = `task-${nanoid(6)}`;
+    const assignedOn = new Date(parsed.startDate);
+    const task: Task = {
+      id,
+      templateVersionId: template.currentVersion.id,
+      teamId: parsed.teamId,
+      assignedOn: formatISO(assignedOn),
+      dueOn: formatISO(addDays(assignedOn, 1)),
+      priority: parsed.priority,
+      location: parsed.location,
+      status: "not_started",
+      notes: parsed.notes,
+      subTasks: template.currentVersion.subTasks.map((subTask, index) => ({
+        id: `${id}-st-${index + 1}`,
+        templateId: subTask.id,
+        label: subTask.label,
+        description: subTask.description,
+        inputType: subTask.inputType,
+        required: subTask.required,
+        target: subTask.defaultTarget,
+        status: "pending",
+      })),
+    };
+    this.data.tasks.push(task);
+    return task;
+  }
+
+  updateSubTask(taskId: string, subTaskId: string, updates: Partial<Task["subTasks"][number]>) {
+    const task = this.data.tasks.find((entry) => entry.id === taskId);
+    if (!task) {
+      throw new Error("Task not found");
+    }
+    const subTask = task.subTasks.find((entry) => entry.id === subTaskId);
+    if (!subTask) {
+      throw new Error("Sub-task not found");
+    }
+    Object.assign(subTask, updates);
+    if (subTask.status === "complete" && subTask.required) {
+      task.status = "in_progress";
+    }
+    const progress = calculateTaskProgress(task);
+    if (progress === 100) {
+      task.status = "done";
+    }
+    return task;
+  }
+
+  moveWeek(offset: number) {
+    const currentStart = startOfWeek(new Date(this.data.tasks[0]?.assignedOn ?? new Date()), { weekStartsOn: 1 });
+    return startOfWeek(addDays(currentStart, offset * 7), { weekStartsOn: 1 });
+  }
+
+  getStatusSummary(weekStart = startOfWeek(new Date(), { weekStartsOn: 1 })) {
+    return this.data.teams.map((team) =>
+      createStatusSummary(
+        this.data.tasks.filter((task) => task.teamId === team.id),
+        team.id,
+        weekStart,
+      ),
+    ).map((summary) => structuredClone(summary));
+  }
+
+  getCalendar(weekStart = startOfWeek(new Date(), { weekStartsOn: 1 })) {
+    const label = weekRangeLabel(weekStart);
+    return {
+      label,
+      cells: buildCalendarMatrix(this.data.tasks, { weekStart }).map((cell) => structuredClone(cell)),
+    };
+  }
+}
+
+export const store = new InMemoryStore(seedData);
+
+export type { InMemoryStore };

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*


### PR DESCRIPTION
## Summary
- replace the previous FastAPI prototype with a pnpm workspace that includes a Next.js 14 web app and shared TypeScript domain/storage packages
- implement dashboard, template management, assignment workflows, and weekly calendar views using shadcn/ui components backed by an in-memory store
- document the new JavaScript architecture and developer commands in the README and refreshed implementation plan

## Testing
- `pnpm install` *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cff4c9d860832faf529c543c698ea9